### PR TITLE
Use latest groovy version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM groovy:2.5-jdk8
+FROM groovy:jdk
 
 LABEL "com.github.actions.name"="Update Gradle Wrapper"
 LABEL "com.github.actions.description"="Updates gradle wrapper for repo"


### PR DESCRIPTION
After playing around with https://github.com/rahulsom/gradle-up/issues/2, a wild guess is to use the latest groovy image (see https://hub.docker.com/_/groovy/ for the current list).

Maybe, one can try?

(edited online - therefore GitHub added the line break at the end)